### PR TITLE
NPE: BluetoothAdapter.getBondedDevices()

### DIFF
--- a/printama/src/main/java/com/anggastudio/printama/Printama.java
+++ b/printama/src/main/java/com/anggastudio/printama/Printama.java
@@ -65,6 +65,11 @@ public class Printama {
     private static BluetoothDevice getPrinter() {
         BluetoothAdapter defaultAdapter = BluetoothAdapter.getDefaultAdapter();
         BluetoothDevice printer = null;
+
+        if (defaultAdapter == null) {
+            return null;
+        }
+
         for (BluetoothDevice device : defaultAdapter.getBondedDevices()) {
             if (device.getName().equalsIgnoreCase(Pref.getString(Pref.SAVED_DEVICE))) {
                 printer = device;


### PR DESCRIPTION
fixed if device hasn't Bluetooth module.
```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.Set android.bluetooth.BluetoothAdapter.getBondedDevices()' on a null object reference
```